### PR TITLE
Avoid memory waste caused by multiple threads using many FastThreadLocal(#8271 #9328)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -43,7 +43,7 @@ import java.util.Set;
  */
 public class FastThreadLocal<V> {
 
-    private static final int variablesToRemoveIndex = InternalThreadLocalMap.nextVariableIndex();
+    private static final int variablesToRemoveIndex = 0;
 
     /**
      * Removes all {@link FastThreadLocal} variables bound to the current thread.  This operation is useful when you
@@ -125,7 +125,7 @@ public class FastThreadLocal<V> {
     private final int index;
 
     public FastThreadLocal() {
-        index = InternalThreadLocalMap.nextVariableIndex();
+        index = InternalThreadLocalMap.get().nextVariableIndex();
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -42,7 +42,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(InternalThreadLocalMap.class);
     private static final ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap =
             new ThreadLocal<InternalThreadLocalMap>();
-    private static final AtomicInteger nextIndex = new AtomicInteger();
+    private int nextIndex = 1;
 
     private static final int DEFAULT_ARRAY_LIST_INITIAL_CAPACITY = 8;
     private static final int STRING_BUILDER_INITIAL_SIZE;
@@ -133,17 +133,17 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         slowThreadLocalMap.remove();
     }
 
-    public static int nextVariableIndex() {
-        int index = nextIndex.getAndIncrement();
+    public int nextVariableIndex() {
+        int index = nextIndex++;
         if (index < 0) {
-            nextIndex.decrementAndGet();
+            nextIndex--;
             throw new IllegalStateException("too many thread-local indexed variables");
         }
         return index;
     }
 
-    public static int lastVariableIndex() {
-        return nextIndex.get() - 1;
+    public int lastVariableIndex() {
+        return nextIndex - 1;
     }
 
     private InternalThreadLocalMap() {

--- a/pom.xml
+++ b/pom.xml
@@ -1018,7 +1018,7 @@
         <configuration>
           <parameter>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
-            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+            <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
             <oldVersionPattern>\d+\.\d+\.\d+\.Final</oldVersionPattern>
             <ignoreMissingClassesByRegularExpressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1019,7 +1019,7 @@
           <parameter>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
-            <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+            <breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
             <oldVersionPattern>\d+\.\d+\.\d+\.Final</oldVersionPattern>
             <ignoreMissingClassesByRegularExpressions>
               <!-- ignore everything which is not part of netty itself as the plugin can not handle optional dependencies -->


### PR DESCRIPTION
Avoid memory waste caused by multiple threads using many FastThreadLocal (#8271 #9328)

Motivation:

Every time one FastThreadLocal is created, the InternalThreadLocalMap.nextIndex is increased.
When multiple threads create many FastThreadLocal, the nextIndex will grow big soon.
FastThreadLocal is created much later, the InternalThreadLocalMap.indexedVariables is expanded more frequently.
But it is unnecessary.

Modifications:

Change InternalThreadLocalMap.nextIndex to instance variable.
FastThreadLocal.index is assigned by InternalThreadLocalMap of current thread.
FastThreadLocal.variablesToRemoveIndex is always zero.

Result:

InternalThreadLocalMap.indexedVariables do not need be expanded when one thread create less than 31 objects of FastThreadLocal.